### PR TITLE
Fix RUF059 violations for ruff 0.15.x

### DIFF
--- a/development/demo/views.py
+++ b/development/demo/views.py
@@ -82,7 +82,7 @@ def social_post(request: HttpRequest, provider: str, slug: str) -> HttpResponse:
         messages.error(request, f"Unsupported provider: {provider}")
         return redirect("/")
 
-    url, msg = post_function(token, oa2)
+    _url, msg = post_function(token, oa2)
     logger.info(msg)
     messages.success(request, msg)
     return redirect("/")

--- a/oauth2_capture/views.py
+++ b/oauth2_capture/views.py
@@ -79,7 +79,7 @@ def oauth2_callback(request: HttpRequest, provider: str) -> HttpResponse:
             logger.warning(f"No user ID found for {provider}, using fallback ID")
             user_id = f"{provider}_user_{request.user.id}"
 
-        oauth_token, created = OAuthToken.objects.get_or_create(
+        oauth_token, _created = OAuthToken.objects.get_or_create(
             provider=provider,
             user_id=user_id,
             owner=request.user,


### PR DESCRIPTION
Ruff 0.15 introduces `RUF059` which flags unpacked tuple variables that are never used. Rename the two hits to `_url` and `_created` so lint passes on the pending Dependabot bumps (#96, #90, #88).

- `development/demo/views.py:85`: `url` → `_url`
- `oauth2_capture/views.py:82`: `created` → `_created`

No behavior change.